### PR TITLE
Close safety_checker in SDControlnetPipeline

### DIFF
--- a/facechain/inference.py
+++ b/facechain/inference.py
@@ -185,7 +185,7 @@ def main_diffusion_inference_pose(pose_model_path, pose_image,
         style_model_path = os.path.join(model_dir, 'zjz_mj_jiyi_small_addtxt_fromleo.safetensors')
 
     controlnet = ControlNetModel.from_pretrained(pose_model_path, torch_dtype=torch.float32)
-    pipe = StableDiffusionControlNetPipeline.from_pretrained(base_model_path, controlnet=controlnet, torch_dtype=torch.float32)
+    pipe = StableDiffusionControlNetPipeline.from_pretrained(base_model_path, safety_checker=None, controlnet=controlnet, torch_dtype=torch.float32)
     pipe.scheduler = UniPCMultistepScheduler.from_config(pipe.scheduler.config)
     pose_im = Image.open(pose_image)
     pose_im = img_pad(pose_im)

--- a/facechain/inference_inpaint.py
+++ b/facechain/inference_inpaint.py
@@ -55,6 +55,7 @@ def build_pipeline_facechain(baseline_model_path, lora_model_path, cache_model_d
     # Build SDInpaint Pipeline
     pipeline = StableDiffusionControlNetInpaintPipeline.from_pretrained(
         baseline_model_path,
+        safety_checker=None,
         controlnet=controlnet,
         torch_dtype=weight_dtype,
     ).to("cuda")


### PR DESCRIPTION
To solve ISSUE139, https://github.com/modelscope/facechain/issues/139
we close SDControlnetPipeline by default