### PR TITLE
Fix sdwebui install script

### DIFF
--- a/install.py
+++ b/install.py
@@ -32,7 +32,14 @@ if not launch.is_installed("onnxruntime"):
 if not launch.is_installed("mmcv"):
     print("--installing mmcv...")
     # Todo 这里有坑
-    launch.run_pip("install mmcv-full==1.7.0", "requirements for mmcv")
+    try:
+        launch.run_pip("install mmcv-full==1.7.0", "requirements for mmcv")
+    except Exception as e:
+        print(e)
+        if os.name == 'nt':  # Windows
+            print('ERROR facechain: failed to install mmcv, make sure to have "CUDA Toolkit" and "Build Tools for Visual Studio" installed')
+        else:
+            print('ERROR facechain: failed to install mmcv')
 
 if not launch.is_installed("mmdet"):
     print("--installing mmdet...")

--- a/install.py
+++ b/install.py
@@ -48,3 +48,19 @@ if not launch.is_installed("mediapipe"):
 if not launch.is_installed("edge_tts"):
     print("--installing edge_tts...")
     launch.run_pip("install edge_tts", "requirements for mediapipe")
+
+# there seems to be a bug in fsspec 2023.10.0 that triggers an Error during training
+# NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.
+# currently webui by default will install 2023.10.0
+# Todo remove fsspec version change after issue is resolved, please monitor situation, it's possible in the future that webui might specify a specific version of fsspec
+import pkg_resources
+required_fsspec_version = '2023.9.2'
+try:
+    fsspec_version = pkg_resources.get_distribution('fsspec').version
+    if fsspec_version != required_fsspec_version:
+        print("--installing fsspec...")
+        launch.run_pip(f"install -U fsspec=={required_fsspec_version}", f"facechain changing fsspec version from {fsspec_version} to {required_fsspec_version}")
+except Exception:
+    # pkg_resources.get_distribution will throw if fsspec installed, since webui install by default fsspec this section shouldn't be necessary
+    print("--installing fsspec...")
+    launch.run_pip(f"install -U fsspec=={required_fsspec_version}", f"requirements for facechain")

--- a/install.py
+++ b/install.py
@@ -25,10 +25,6 @@ if not launch.is_installed("controlnet_aux"):
     print("--installing controlnet_aux...")
     launch.run_pip("install controlnet_aux==0.0.6", "requirements for controlnet_aux")
 
-if not launch.is_installed("onnxruntime"):
-    print("--installing onnxruntime...")
-    launch.run_pip("install onnxruntime==1.15.1", "requirements for onnxruntime")
-
 if not launch.is_installed("mmcv"):
     print("--installing mmcv...")
     # Todo 这里有坑

--- a/install.py
+++ b/install.py
@@ -9,8 +9,8 @@ if not launch.is_installed("slugify"):
     launch.run_pip("install python-slugify==8.0.1", "requirements for python-slugify")
 
 if not launch.is_installed("diffusers"):
-    print("--installing diffuers...")
-    launch.run_pip("install diffuers", "requirements for diffuers")
+    print("--installing diffusers...")
+    launch.run_pip("install diffusers", "requirements for diffusers")
 
 if not launch.is_installed("onnxruntime") and not launch.is_installed("onnxruntime-gpu"):
     import torch.cuda as cuda


### PR DESCRIPTION
@wenmengzhou
Fix sdwebui install script
commit [fix typo diffuers -> diffusers](https://github.com/modelscope/facechain/commit/6796d2e7800ec32f958cee82dddb79c702c1f8d7) self explanatory

commit [handle mmcv fail install](https://github.com/modelscope/facechain/commit/49944a7352c5683a8ad2782dd673de30a1bd74e7)
at least in my environment, win11 3090, install mmcv-full==1.7.0 building from source, which means one have to have `Build Tools for Visual Studio` and `CUDA Toolkit` installed and set up in the environment
if one doesn't have the required environment naturally it will fail to install
the average user will not know what's going on, so I added a minimum message pointing the user at the right direction
however this message may not be sufficient I advise adding instructions on how to set up the environment in the readme or some where else
> note since I'm on win11, I'm not sure what are the requirements of installing it on linux or other platforms, if necessary please add in the message for non Windows platform

commit [remove duplicate onnxruntime install](https://github.com/modelscope/facechain/commit/004bb7e0957c75627f51abfb3bf037a67e1fb6a3)
remove the duplicate one so it doesn't break things

commit [change fsspec to 2023.9.2](https://github.com/modelscope/facechain/commit/ca69eae3267c54efac8fa555a6bdee90f51bab9f)
as described in comments there seems to be a bug recently update version of fsspec 2023.10.0
which is the version automatically installed by default by web UI on new installes
here I added logic to downgrade to the previous version 2023.9.2
https://pypi.org/project/fsspec/#history

please monitor the situation and act accordingly
if the issue has been resolved in new releases of fsspec or if sdwebui has changed its requirements on this package

related discussion
https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/206
