### PR TITLE
upgrade tensorflow to avoid numpy mismatch

### DIFF
--- a/facechain_demo.ipynb
+++ b/facechain_demo.ipynb
@@ -1,116 +1,107 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "private_outputs": true,
-   "provenance": [],
-   "machine_shape": "hm",
-   "name": "facechain-demo.ipynb"
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "AzOycrSUkK-0"
+   },
    "source": [
     "Requirements:\n",
     "- GPU Mem Usage: 19G\n",
     "- Disk Usage: About 50G"
-   ],
-   "metadata": {
-    "id": "AzOycrSUkK-0"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Get facechain source code from GitHub"
-   ],
    "metadata": {
     "id": "8yQEWTkekIx9"
-   }
+   },
+   "source": [
+    "## Get facechain source code from GitHub"
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "!GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/modelscope/facechain.git --depth 1"
-   ],
+   "execution_count": null,
    "metadata": {
     "id": "WK_uDw0NkHTP"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "!GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/modelscope/facechain.git --depth 1"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "jUWWSGDG1ZGK"
+   },
    "source": [
     "## Installation requirements\n",
     "- Note that you can ignore warning on dependencies conflicts at the end\n",
     "- You may use conda virtual env to avoid warning info."
-   ],
-   "metadata": {
-    "id": "jUWWSGDG1ZGK"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "!pip3 install -r facechain/requirements.txt"
-   ],
+   "execution_count": null,
    "metadata": {
     "id": "QrwRDBipxKZw"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "!pip3 install -r facechain/requirements.txt"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Check environment informaiton"
-   ],
    "metadata": {
     "id": "0miaB1nC2VrA"
-   }
+   },
+   "source": [
+    "## Check environment informaiton"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uvNE0kRxyI4q"
+   },
+   "outputs": [],
    "source": [
     "!nvidia-smi\n",
     "!pip3 show torch\n",
     "\n",
     "# Note that this setup is verified on (cuda 12.0, torch2.0.1+cu118, Nvidia-A100 40G)"
-   ],
-   "metadata": {
-    "id": "uvNE0kRxyI4q"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [],
    "metadata": {
     "id": "klba298h2bbu"
-   }
+   },
+   "source": []
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "ciSxxSzI4l_u"
+   },
    "source": [
     "## Installing mmcv-full\n",
     "- Several of the underlying models depend on mmcv-full, which could be tricky to install since it is environment-dependent, you may refer to [mmcv's official documentation](https://mmcv.readthedocs.io/zh_CN/latest/get_started/installation.html) for more details..\n",
     "- A prebuilt package is provided here for convenience, and was verified on (cuda 12.0, torch2.0.1+cu118, Nvidia-A100 40G)\n",
     "- If the prebuilt package does not work on your env setup, please use the alternative installation as suggested by [mmcv's official documentation](https://mmcv.readthedocs.io/zh_CN/latest/get_started/)"
-   ],
-   "metadata": {
-    "id": "ciSxxSzI4l_u"
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "t2lciBXyyuzA"
+   },
+   "outputs": [],
    "source": [
     "# use prebuilt mmcv-full package provided by ModelScope (verified on cuda 12.0, torch2.0.1+cu118, Nvidia-A100 40G)\n",
     "!pip3 install https://modelscope.oss-cn-beijing.aliyuncs.com/packages/mmcv/mmcv_full-1.7.0-cp310-cp310-linux_x86_64.whl\n",
@@ -118,25 +109,23 @@
     "# alternative manual installtation. note that it may take 30+ mins for building dependencies.\n",
     "# !pip3 install -U openmim\n",
     "# !mim install mmcv-full==1.7.0\n"
-   ],
-   "metadata": {
-    "id": "t2lciBXyyuzA"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Pre-download models to mitigate connection timeout issue"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "## Pre-download models to mitigate connection timeout issue"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -146,22 +135,33 @@
     "# Not required\n",
     "from facechain.utils import pre_download_models\n",
     "pre_download_models()"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "## Start facechain WebUI service"
-   ],
-   "metadata": {
-    "id": "OxDgRY8H4vta"
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade tensorflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OxDgRY8H4vta"
+   },
+   "source": [
+    "## Start facechain WebUI service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NW5o0iiezTCg"
+   },
+   "outputs": [],
    "source": [
     "# Install service dependencies\n",
     "!pip3 install gradio==3.50.2\n",
@@ -172,12 +172,21 @@
     "\n",
     "# Click on the gradio URL to start building your FaceChain digital-twin!\n",
     "!python3 app.py"
-   ],
-   "metadata": {
-    "id": "NW5o0iiezTCg"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "machine_shape": "hm",
+   "name": "facechain-demo.ipynb",
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
From my test with Google Colab, you need to upgrade tensorflow to avoid this error

```
2023-11-18 19:50:43,142 - modelscope - INFO - Loading done! Current index file version is 1.9.5, with md5 b06591488beecfd1cdae8665edf13601 and a total number of 945 components indexed
2023-11-18 19:50:44.948671: E tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:9342] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2023-11-18 19:50:44.948729: E tensorflow/compiler/xla/stream_executor/cuda/cuda_fft.cc:609] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2023-11-18 19:50:44.948773: E tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.cc:1518] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xf
```