### PR TITLE
Add max version for diffusers requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 transformers
 onnxruntime==1.15.1
-diffusers>=0.23.0
+diffusers>=0.23.0,<0.26
 invisible-watermark>=0.2.0
 modelscope==1.10.0
 Pillow


### PR DESCRIPTION
Resolves https://github.com/modelscope/facechain/issues/508
`diffusers 0.26.0` deprecates some core functionalities in use by FaceChain. This is a simple fix until the deprecated codes are updated.